### PR TITLE
fix undefined uint8_t when building with GCC 13

### DIFF
--- a/include/some_types.h
+++ b/include/some_types.h
@@ -1,6 +1,8 @@
 #ifndef SOM_TYPES_H_INCLUDED
 #define SOM_TYPES_H_INCLUDED
 
+#include <cstdint>
+
 namespace hiberlite{
 
 template<class E, class C>


### PR DESCRIPTION
fix undefined uint8_t when building with GCC 13 by adding `#include <cstdint>` to `include/some_types.h`